### PR TITLE
add demo notebook

### DIFF
--- a/examples/CMNN_demo.ipynb
+++ b/examples/CMNN_demo.ipynb
@@ -1,0 +1,387 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# RAIL CMNN Tutorial Notebook\n",
+    "\n",
+    "author: Sam Schmidt<br>\n",
+    "last run successfully: May 31, 2023<br>\n",
+    "\n",
+    "This is a notebook demonstrating some of the features of the LSSTDESC `RAIL` version of the CMNN estimator, see **[Graham et al. (2018)](https://ui.adsabs.harvard.edu/abs/2018AJ....155....1G/abstract)** for more details on the algorithm.<br>\n",
+    "\n",
+    "CMNN stands for color-matched nearest-neighbor, and as this name implies, the method works by finding the Mahalanobis distance between each test galaxy and the training galaxies, and selecting one of those \"nearby\" in color space as the redshift estimate.  The algorithm also estimates the \"width\" of the resulting PDF based on the standard deviation of this nearby set and returns a single Gaussian with a mean and width defined as such.<br>\n",
+    "\n",
+    "The current version of the code consists of a training stage, `Inform_CMNNPDF`, that computes colors for a set of training data (replacing non-detections with the 1-sigma limiting magnitude), and an estimation stage `CMNNPDF` that calculates the Mahalanobis distance to each training galaxy for each test galaxy and returns a single Guassian PDF for each galaxy where the mean can be estimated in one of three ways (see selection mode below), and the width is determined by the standard deviation of training galaxy redshifts within the threshold Mahalanobis distance. Future implementation improvements may change the output format to include multiple Gaussians.\n",
+    "\n",
+    "In addition to the Gaussian PDF for each test galaxy, two ancillary quantities are stored: `zmode`: the mode of the redshift PDF and `Ncm`, the integer number of \"nearby\" galaxies considered as neighbors for each galaxy.<br>\n",
+    "\n",
+    "`Inform_CMNNPDF` takes in a training data set and returns a model file that simply consists of the computed colors and color errors (magnitude errors added in quadrature) for that dataset, the model to be used in the `CMNNPDF` stage. A modification of the original CMNN algorithm, \"nondetections\" are now replaced by the 1-sigma limiting magnitudes and the non-detect magnitude errors replaced with a value of 1.0. The config parameters that can be set by the user for `Inform_CMNNPDF` are:\n",
+    "\n",
+    "- bands: list of the band names that should be present in the input data.<br>\n",
+    "- err_bands: list of the magnitude error column names that should be present in the input data.<br>\n",
+    "- redshift_col: a string giving the name for the redshift column present in the input data.<br>\n",
+    "- mag_limits: a dictionary with keys that match those in bands and a float with the 1 sigma limiting magnitude for each band.<br>\n",
+    "- nondetect_val: float or np.nan, the value indicating a non-detection, which will be replaced by the values in mag_limits.<br>\n",
+    "\n",
+    "\n",
+    "The parameters that can be set via the config_params in `CMNNPDF` are described in brief below:\n",
+    "\n",
+    "- bands, err_bands, redshift_col, mag_limits are all the same as described above for Inform_CMNNPDF.\n",
+    "- ppf_value: float, usually 0.68 or 0.95, which sets the value of the PPF used in the Mahalanobis distance calculation.\n",
+    "- selection_mode: int, selects how the central value of the Gaussian PDF is calculated in the algorithm, if set to **0** randomly chooses from set within the Mahalanobis distance, if set to **1** chooses the nearest neighbor point, if set to **2** adds a distance weight to the random choice.\n",
+    "- min_n: int, the minimum number of training galaxies to use.\n",
+    "- min_thresh: float, the minimum threshold cutoff. Values smaller than this threshold value will be ignored.\n",
+    "- min_dist: float, the minimum Mahalanobis distance. Values smaller than this will be ignored.\n",
+    "- bad_redshift_val: float, in the unlikely case that there are not enough training galaxies, this central redshift will be assigned to galaxies.\n",
+    "- bad_redshift_err: float, in the unlikely case that there are not enough training galaxies, this Gaussian width will be assigned to galaxies.\n",
+    "\n",
+    "\n",
+    "Let's grab some example data, train the model by running the `Inform_CMNNPDF` `inform` method, then calculate a set of photo-z's using `CMNNPDF` `estimate`.  Much of the following is copied from the `RAIL_estiation_demo.ipynb` in the RAIL repo, so look at that notebook for general questions on setting up the RAIL infrastructure for estimators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "%matplotlib inline "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import rail\n",
+    "import qp\n",
+    "from rail.core.data import TableHandle\n",
+    "from rail.core.stage import RailStage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DS = RailStage.data_store\n",
+    "DS.__class__.allow_overwrite = True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Getting the list of available Estimators\n",
+    "\n",
+    "RailStage knows about all of the sub-types of stages.  The are stored in the `RailStage.pipeline_stages` dict.  By looping through the values in that dict we can and asking if each one is a sub-class of `rail.estimation.estimator.CatEstimator` we can identify the available estimators that operator on catalog-like inputs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The code-specific parameters\n",
+    "As mentioned above, CMNN has particular configuration options that can be set when setting up an instance of our `Inform_CMNNPDF` stage, we'll define those in a dictionary.  Any parameters not specifically assigned will take on default values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cmnn_dict = dict(zmin=0.0, zmax=3.0, nzbins=301, hdf5_groupname='photometry')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will begin by training the algorithm, to to this we instantiate a rail object with a call to the base class.<br>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rail.estimation.algos.cmnn import Inform_CMNNPDF, CMNNPDF\n",
+    "pz_train = Inform_CMNNPDF.make_stage(name='inform_CMNN', model='demo_cmnn_model.pkl', **cmnn_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, let's load our training data, which is stored in hdf5 format.  We'll load it into the Data Store so that the ceci stages are able to access it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rail.core.utils import RAILDIR\n",
+    "trainFile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_training_9816.hdf5')\n",
+    "testFile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_validation_9816.hdf5')\n",
+    "training_data = DS.read_file(\"training_data\", TableHandle, trainFile)\n",
+    "test_data = DS.read_file(\"test_data\", TableHandle, testFile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The inform stage for CMNN should not take long to run, it essentially just converts the magnitudes to colors for the training data and stores those as a model dictionary which is stored in a pickle file specfied by the `model` keyword above, in this case \"demo_cmnn_model.pkl\". This file should appear in the directory after we run the inform stage in the cell below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "pz_train.inform(training_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now set up the main photo-z stage and run our algorithm on the data to produce simple photo-z estimates.  Note that we are loading the trained model that we computed from the inform stage: with the `model=pz_train.get_handle('model')` statement.<br>\n",
+    "\n",
+    "Let's also set the minumum number of neighbors to 24, and the `selection_mode` to \"1\", which will choose the nearest neighbor for each galaxy as the redshift estimate:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "pz = CMNNPDF.make_stage(name='CMNN', hdf5_groupname='photometry',\n",
+    "                        model=pz_train.get_handle('model'),\n",
+    "                        min_n=20,\n",
+    "                        selection_mode=1,\n",
+    "                        aliases={\"output\":\"pz_near\"})\n",
+    "results = pz.estimate(test_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As mentioned above, in addition to the PDF, `estimate` calculates and stores both the mode of the PDF (`zmode`), and the number of neighbors (`Ncm`) for each galaxy, which can be accessed from the ancillary data.  We will plot the modes vs the true redshift to see how well CMNN did in estimating redshifts:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zmode = results().ancil['zmode']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's plot the redshift mode against the true redshifts to see how they look:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(8,8))\n",
+    "plt.scatter(test_data()['photometry']['redshift'],zmode,s=1,c='k',label='simple NN mode')\n",
+    "plt.plot([0,3],[0,3],'r--');\n",
+    "plt.xlabel(\"true redshift\")\n",
+    "plt.ylabel(\"CMNN photo-z mode\")\n",
+    "plt.ylim(0,3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Very nice!  Not many outliers and a fairly small scatter without much biase!\n",
+    "\n",
+    "Now, let's plot the histogram of how many neighbors were used.  We set a minimum number of 20, so we should see a large peak at that value: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ncm =results().ancil['Ncm']\n",
+    "plt.hist(ncm, bins=np.linspace(0,200,20));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As mentioned previously, we can change the method for how we select the mean redshift, let's re-run the estimator but use `selection_mode` = \"0\", which will select a random galaxy from amongst the neighbors.  This should still look decent, but perhaps not as nice as the nearest neighbor estimator:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pz_rand = CMNNPDF.make_stage(name='CMNN_rand', hdf5_groupname='photometry',\n",
+    "                             model=pz_train.get_handle('model'),\n",
+    "                             min_n=20,\n",
+    "                             selection_mode=0,\n",
+    "                             aliaes={\"output\": \"pz_rand\"})\n",
+    "results_rand = pz_rand.estimate(test_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zmode_rand = results_rand().ancil['zmode']\n",
+    "plt.figure(figsize=(8,8))\n",
+    "plt.scatter(test_data()['photometry']['redshift'],zmode_rand,s=1,c='k',label='simple NN mode')\n",
+    "plt.plot([0,3],[0,3],'r--');\n",
+    "plt.xlabel(\"true redshift\")\n",
+    "plt.ylabel(\"CMNN photo-z mode\")\n",
+    "plt.ylim(0,3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Slightly worse, but not dramatically so, a few more outliers are visible visually.  Finally, we can try the weighted random selection by setting `selection_mode` to \"2\":"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pz_weight = CMNNPDF.make_stage(name='CMNN_weight', hdf5_groupname='photometry',\n",
+    "                               model=pz_train.get_handle('model'),\n",
+    "                               min_n=20,\n",
+    "                               selection_mode=2,\n",
+    "                               aliaes={\"output\": \"pz_weight\"})\n",
+    "results_weight = pz_weight.estimate(test_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zmode_weight = results_weight().ancil['zmode']\n",
+    "plt.figure(figsize=(8,8))\n",
+    "plt.scatter(test_data()['photometry']['redshift'],zmode_weight,s=1,c='k',label='simple NN mode')\n",
+    "plt.plot([0,3],[0,3],'r--');\n",
+    "plt.xlabel(\"true redshift\")\n",
+    "plt.ylabel(\"CMNN photo-z mode\")\n",
+    "plt.ylim(0,3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Again, not a dramatic difference, but it can make a difference if there is sparse coverage of areas of the color-space by the training data, where choosing \"nearest\" might choose the same single data point for many test points, whereas setting to random or weighted random could slightly \"smooth\" that choice by forcing choices of other nearby points for the redshift estimate."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, let's plot a few PDFs, again, they are a single Gaussian:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results().plot_native(key=9, xlim=(0,3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results().plot_native(key=1554, xlim=(0,3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results().plot_native(key=19554, xlim=(0,3))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We see a wide variety of widths, as expected for a single Gaussian parameterization that must encompass a wide variety of PDF shapes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pz-rail-cmnn"
 description = "RAIL CMNN Interface"
-readme = "README.rst"
+readme = "README.md"
 requires-python = ">=3.8"
 license = { file = "LICENSE" }
 authors = [


### PR DESCRIPTION
Adds a demo notebook to show usage of the CMNN estimator and a couple quick plots of the mode vs spec-z a la the RAIL_estimation-demo notebook.