### PR TITLE
Removing two outdated tests, changing pylint commands

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
         pip install pylint
         # stop the build if there are Pylint errors
         # pylint --disable=all --extension-pkg-whitelist=numpy --init-hook='import sys; sys.setrecursionlimit(8 * sys.getrecursionlimit())' rail
-        pylint --disable=all --recursive=y --extension-pkg-whitelist=numpy  *.py
+        pylint --recursive=y --extension-pkg-whitelist=numpy  .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,8 @@ jobs:
       run: |
         pip install pylint
         # stop the build if there are Pylint errors
-        pylint --disable=all --extension-pkg-whitelist=numpy --init-hook='import sys; sys.setrecursionlimit(8 * sys.getrecursionlimit())' rail
+        # pylint --disable=all --extension-pkg-whitelist=numpy --init-hook='import sys; sys.setrecursionlimit(8 * sys.getrecursionlimit())' rail
+        pylint --recursive=y --extension-pkg-whitelist=numpy .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,8 +50,7 @@ jobs:
       run: |
         pip install pylint
         # stop the build if there are Pylint errors
-        # pylint --disable=all --extension-pkg-whitelist=numpy --init-hook='import sys; sys.setrecursionlimit(8 * sys.getrecursionlimit())' rail
-        ! pylint --recursive=y --extension-pkg-whitelist=numpy  .
+        pylint --recursive=y --exit-zero --extension-pkg-whitelist=numpy .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
         pip install pylint
         # stop the build if there are Pylint errors
         # pylint --disable=all --extension-pkg-whitelist=numpy --init-hook='import sys; sys.setrecursionlimit(8 * sys.getrecursionlimit())' rail
-        pylint --recursive=y --extension-pkg-whitelist=numpy  .
+        ! pylint --recursive=y --extension-pkg-whitelist=numpy  .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
         pip install pylint
         # stop the build if there are Pylint errors
         # pylint --disable=all --extension-pkg-whitelist=numpy --init-hook='import sys; sys.setrecursionlimit(8 * sys.getrecursionlimit())' rail
-        pylint --disable=all --recursive=y --extension-pkg-whitelist=numpy .
+        pylint --disable=all --recursive=y --extension-pkg-whitelist=numpy  *.py
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
         pip install pylint
         # stop the build if there are Pylint errors
         # pylint --disable=all --extension-pkg-whitelist=numpy --init-hook='import sys; sys.setrecursionlimit(8 * sys.getrecursionlimit())' rail
-        pylint --recursive=y --extension-pkg-whitelist=numpy .
+        pylint --disable=all --recursive=y --extension-pkg-whitelist=numpy .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Lint with pylint
       run: |
         pip install pylint
-        # stop the build if there are Pylint errors
+        # do not stop the build if there are Pylint errors
         pylint --recursive=y --exit-zero --extension-pkg-whitelist=numpy .
     - name: Lint with flake8
       run: |

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -56,19 +56,3 @@ def test_cmnn_nondetect_replace():
     results, rerun_results, rerun3_results = one_algo("CMNN", train_algo, pz_algo, train_config_dict, estim_config_dict)
     assert np.isclose(results.ancil['zmode'], zb_expected, atol=0.02).all()
     assert np.isclose(results.ancil['zmode'], rerun_results.ancil['zmode']).all()
-
-
-#def test_missing_groupname_keyword(): # small change to trigger action, to confirm this failing
-#    config_dict = default_dict.copy()
-#    with pytest.raises(ValueError):
-#        _ = cmnn.CMNNPDF.make_stage(**config_dict)
-
-
-def test_wrong_modelfile_keyword():
-    RailStage.data_store.clear()
-    config_dict = default_dict.copy()
-    config_dict["hdf5_groupname"] = "photometry"
-    config_dict["model"] = "notreal.pkl"
-    with pytest.raises(FileNotFoundError):
-        pz_algo = cmnn.CMNNPDF.make_stage(**config_dict)
-        assert pz_algo.model is None

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -56,18 +56,3 @@ def test_cmnn_nondetect_replace():
     )
     assert np.isclose(results.ancil["zmode"], zb_expected, atol=0.02).all()
     assert np.isclose(results.ancil["zmode"], rerun_results.ancil["zmode"]).all()
-
-
-def test_wrong_modelfile_keyword():
-    RailStage.data_store.clear()
-    config_dict = default_dict.copy()
-    config_dict["hdf5_groupname"] = "photometry"
-    config_dict["model"] = "notreal.pkl"
-    with pytest.raises(FileNotFoundError):
-        pz_algo = cmnn.CMNNPDF.make_stage(**config_dict)
-        assert pz_algo.model is None
-
-
-if __name__ == "__main__":
-    print("ok!!")
-    test_wrong_modelfile_keyword()

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -58,10 +58,10 @@ def test_cmnn_nondetect_replace():
     assert np.isclose(results.ancil['zmode'], rerun_results.ancil['zmode']).all()
 
 
-def test_missing_groupname_keyword(): # small change to trigger action, to confirm this failing
-    config_dict = default_dict.copy()
-    with pytest.raises(ValueError):
-        _ = cmnn.CMNNPDF.make_stage(**config_dict)
+#def test_missing_groupname_keyword(): # small change to trigger action, to confirm this failing
+#    config_dict = default_dict.copy()
+#    with pytest.raises(ValueError):
+#        _ = cmnn.CMNNPDF.make_stage(**config_dict)
 
 
 def test_wrong_modelfile_keyword():

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -6,22 +6,17 @@ from rail.core.algo_utils import one_algo
 from rail.core.utils import RAILDIR
 from rail.estimation.algos import cmnn
 
-default_dict = {'zmin': 0.0, 'zmax': 3.0, 'nzbins': 301, 'min_n': 4}
+default_dict = {"zmin": 0.0, "zmax": 3.0, "nzbins": 301, "min_n": 4}
 
 
-@pytest.mark.parametrize("out_method,zb_expected",
-                         [
-                             (0, np.array([0.15, 0.14, 0.12,
-                                           0.13, 0.15, 0.12, 0.15,
-                                           0.14, 0.12, 0.15])),
-                             (1, np.array([0.11, 0.15, 0.14,
-                                           0.13, 0.11, 0.13, 0.15,
-                                           0.15, 0.11, 0.11])),
-                             (2, np.array([0.15, 0.10, 0.12,
-                                           0.13, 0.11, 0.13, 0.15,
-                                           0.14, 0.11, 0.14]))
-                         ])
-                         
+@pytest.mark.parametrize(
+    "out_method,zb_expected",
+    [
+        (0, np.array([0.15, 0.14, 0.12, 0.13, 0.15, 0.12, 0.15, 0.14, 0.12, 0.15])),
+        (1, np.array([0.11, 0.15, 0.14, 0.13, 0.11, 0.13, 0.15, 0.15, 0.11, 0.11])),
+        (2, np.array([0.15, 0.10, 0.12, 0.13, 0.11, 0.13, 0.15, 0.14, 0.11, 0.14])),
+    ],
+)
 def test_cmnn(out_method, zb_expected):
     train_config_dict = default_dict.copy()
     estim_config_dict = default_dict.copy()
@@ -35,9 +30,11 @@ def test_cmnn(out_method, zb_expected):
     #                         0.12, 0.12])
     train_algo = cmnn.Inform_CMNNPDF
     pz_algo = cmnn.CMNNPDF
-    results, rerun_results, rerun3_results = one_algo("CMNN", train_algo, pz_algo, train_config_dict, estim_config_dict)
-    assert np.isclose(results.ancil['zmode'], zb_expected, atol=0.02).all()
-    assert np.isclose(results.ancil['zmode'], rerun_results.ancil['zmode']).all()
+    results, rerun_results, rerun3_results = one_algo(
+        "CMNN", train_algo, pz_algo, train_config_dict, estim_config_dict
+    )
+    assert np.isclose(results.ancil["zmode"], zb_expected, atol=0.02).all()
+    assert np.isclose(results.ancil["zmode"], rerun_results.ancil["zmode"]).all()
 
 
 def test_cmnn_nondetect_replace():
@@ -49,19 +46,14 @@ def test_cmnn_nondetect_replace():
 
     estim_config_dict["hdf5_groupname"] = "photometry"
     estim_config_dict["model"] = "model.tmp"
-    zb_expected = np.array([0.11, 0.15, 0.14, 0.13, 0.11, 0.13, 0.15, 0.15,
-                            0.11, 0.11])
+    zb_expected = np.array([0.11, 0.15, 0.14, 0.13, 0.11, 0.13, 0.15, 0.15, 0.11, 0.11])
     train_algo = cmnn.Inform_CMNNPDF
     pz_algo = cmnn.CMNNPDF
-    results, rerun_results, rerun3_results = one_algo("CMNN", train_algo, pz_algo, train_config_dict, estim_config_dict)
-    assert np.isclose(results.ancil['zmode'], zb_expected, atol=0.02).all()
-    assert np.isclose(results.ancil['zmode'], rerun_results.ancil['zmode']).all()
-
-
-#def test_missing_groupname_keyword(): # small change to trigger action, to confirm this failing
-#    config_dict = default_dict.copy()
-#    with pytest.raises(ValueError):
-#        _ = cmnn.CMNNPDF.make_stage(**config_dict)
+    results, rerun_results, rerun3_results = one_algo(
+        "CMNN", train_algo, pz_algo, train_config_dict, estim_config_dict
+    )
+    assert np.isclose(results.ancil["zmode"], zb_expected, atol=0.02).all()
+    assert np.isclose(results.ancil["zmode"], rerun_results.ancil["zmode"]).all()
 
 
 def test_wrong_modelfile_keyword():
@@ -72,3 +64,8 @@ def test_wrong_modelfile_keyword():
     with pytest.raises(FileNotFoundError):
         pz_algo = cmnn.CMNNPDF.make_stage(**config_dict)
         assert pz_algo.model is None
+
+
+if __name__ == "__main__":
+    print("ok!!")
+    test_wrong_modelfile_keyword()

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -58,7 +58,7 @@ def test_cmnn_nondetect_replace():
     assert np.isclose(results.ancil['zmode'], rerun_results.ancil['zmode']).all()
 
 
-def test_missing_groupname_keyword():
+def test_missing_groupname_keyword(): # small change to trigger action, to confirm this failing
     config_dict = default_dict.copy()
     with pytest.raises(ValueError):
         _ = cmnn.CMNNPDF.make_stage(**config_dict)


### PR DESCRIPTION
# Removing two outdated tests, changing pylint commands

For #10 

## Removed Tests
Removed `test_missing_groupname_keyword`, as [changes to the estimator stage](https://github.com/LSSTDESC/rail_base/blob/cccd4c8aa8a561236f8adfaa7ec863dc8a7bfde4/src/rail/estimation/estimator.py#L30) mean it no longer should raise the ValueError.

In addition, it seems we no longer raise a ValueError when initializing a CatEstimator with a non-existent model file. After discussion, we've decided this is the way to go - a pipeline will check all required files are there before it is run; and while this does not work the same in interactive/notebook mode, building a tool to check for this is a discussion for later.

## Pylint
Failing with an exit code 32, along with the line `pylint No files to lint: exiting.`. 

I removed some unused import statements and disabled a couple of unused variable complaints, but ultimately got past this by changing the line:
`pylint --disable=all --extension-pkg-whitelist=numpy --init-hook='import sys; sys.setrecursionlimit(8 * sys.getrecursionlimit())' rail`
to:
`pylint --recursive=y --exit-zero --extension-pkg-whitelist=numpy .`
This does check for pylint errors, but will let the workflow continue regardless of errors.

I'm guessing this was the intention of `--disable=all` of the previous version.