### PR TITLE
Update for ceci version 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "ceci",
     "numpy",
     "scipy>=1.9",
-    "ceci2 @ https://github.com/LSSTDESC/rail_base",
+    "ceci2 @ git+https://github.com/LSSTDESC/rail_base",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "ceci",
     "numpy",
     "scipy>=1.9",
-    "ceci2 @ git+https://github.com/LSSTDESC/rail_base",
+    "pz_rail_base @ git+https://github.com/LSSTDESC/rail_base@ceci2",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "ceci",
     "numpy",
     "scipy>=1.9",
-    "pz-rail-base",
+    "ceci2 @ https://github.com/LSSTDESC/rail_base",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "ceci",
     "numpy",
     "scipy>=1.9",
-    "pz_rail_base @ git+https://github.com/LSSTDESC/rail_base@ceci2",
+    "pz-rail-base>=1.0.3",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "ceci",
     "numpy",
     "scipy>=1.9",
-    "pz_rail_base @ git+https://github.com/LSSTDESC/rail_base@ceci2",
+    "pz_rail_base",
 ]
 
 

--- a/src/rail/estimation/algos/cmnn.py
+++ b/src/rail/estimation/algos/cmnn.py
@@ -44,10 +44,10 @@ class CMNNInformer(CatInformer):
                           nondetect_replace=Param(bool, False, msg="set to True to replace non-detects,"
                                                   " False to ignore in distance calculation"))
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """ Constructor
         Do CatInformer specific initialization, then check on bands """
-        CatInformer.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
 
     def run(self):
         if self.config.hdf5_groupname:
@@ -124,13 +124,13 @@ class CMNNEstimator(CatEstimator):
                           bad_redshift_err=Param(float, 10., msg="Gauss error width to assign to bad redshifts")
                           )
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """ Constructor:
         Do Estimator specific initialization """
         self.truezs = None
         self.model = None
         self.zgrid = None
-        CatEstimator.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         usecols = self.config.bands.copy()
         usecols.append(self.config.redshift_col)
         self.usecols = usecols

--- a/src/rail/estimation/algos/cmnn.py
+++ b/src/rail/estimation/algos/cmnn.py
@@ -47,7 +47,7 @@ class CMNNInformer(CatInformer):
     def __init__(self, args, **kwargs):
         """ Constructor
         Do CatInformer specific initialization, then check on bands """
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
 
     def run(self):
         if self.config.hdf5_groupname:
@@ -130,7 +130,7 @@ class CMNNEstimator(CatEstimator):
         self.truezs = None
         self.model = None
         self.zgrid = None
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         usecols = self.config.bands.copy()
         usecols.append(self.config.redshift_col)
         self.usecols = usecols


### PR DESCRIPTION
This PR updates the constructors of all stage subclasses to work with ceci version 2, in which aliases are specified in the constructor. A similar PR has been opened for each RAIL repo.

The main change is to the the constructors to accept any keywords with **kwargs and pass them to the parent class.

I have also removed any constructors which did not do anything except call the parent class constructor. Since this happens automatically if you omit the constructor, these were redundant.

Finally, in constructors I have changed I have removed hard-coded parent classes in favour of the python3 recommended super() function. If the parent class are changed in the future the constructor will still work.